### PR TITLE
fix: added extra languages, footer fix and minor fixes

### DIFF
--- a/docs/ad-placements/brave-browser/dynamic-ntt.md
+++ b/docs/ad-placements/brave-browser/dynamic-ntt.md
@@ -7,6 +7,6 @@ title: Dynamic NTT
 
 **[Contact us](https://ads.brave.com/contact)** to inquire about Dynamic New Tab Takeovers.
 
-- <a href="/demos/dynamic-ntt/pan-and-zoom-1" target="_blank">**Pan & Zoom - 1**</a>
+- <a href="/demos/dynamic-ntt/pan-and-zoom" target="_blank">**Pan & Zoom**</a>
 - <a href="/demos/dynamic-ntt/carousel-autofade" target="_blank">**Carousel - autofade**</a>
 - <a href="/demos/dynamic-ntt/slider" target="_blank">**Slider**</a>

--- a/docs/demos/dynamic-ntt/pan-and-zoom.md
+++ b/docs/demos/dynamic-ntt/pan-and-zoom.md
@@ -2,7 +2,7 @@
 sidebar_class_name: hidden
 ---
 
-# Pan & Zoom 1
+# Pan & Zoom
 
 import DynamicNTT from '@site/src/pages/dynamic-ntt';
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -43,7 +43,7 @@ const config: Config = {
   // may want to replace "en" with "zh-Hans".
   i18n: {
     defaultLocale: 'en',
-    locales: ['en', 'es', 'pt'],
+    locales: ['de', 'en', 'es', 'fr', 'pt'],
   },
   
   headTags: [

--- a/i18n/de/docusaurus-plugin-content-docs/current/ad-placements/brave-search/keyword.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/ad-placements/brave-search/keyword.md
@@ -4,9 +4,9 @@ sidebar_position: 1
 
 # Suchanzeigen
 
-**Dieses Produkt ist derzeit nur für Unternehmenskunden verfügbar, die einen Mindestkriterien erfüllen. Bitte kontaktiere adsales@brave.com für Anfragen.** Brave Search ist die Standardsuchmaschine im Brave Browser und die am schnellsten wachsende Suchmaschine seit Bing. Suchanzeigen werden angezeigt, wenn ein Nutzer Suchanfragen eingibt, die mit den vom Werbetreibenden generierten Keywords basieren auf der Website des Werbetreibenden übereinstimmen. Wenn ein User zum Beispiel die Anfrage „blaue Schuhe“ eingibt, wird eine Anzeige von einem Werbetreibenden angezeigt, der Schuhe auf seiner Website verkauft. Wenn keine relevante Anzeige für die Suchanfrage vorhanden ist, wird stattdessen ein organisches Ergebnis angezeigt. ![Search.png](/img/Search.png)
+**Dieses Produkt ist derzeit nur für Unternehmenskunden verfügbar, die einen Mindestkriterien erfüllen. Bitte kontaktiere adsales@brave.com für Anfragen.** Brave Search ist die Standardsuchmaschine im Brave Browser und die am schnellsten wachsende Suchmaschine seit Bing. Suchanzeigen werden angezeigt, wenn ein Nutzer Suchanfragen eingibt, die mit den vom Werbetreibenden generierten Keywords basieren auf der Website des Werbetreibenden übereinstimmen. Wenn ein User zum Beispiel die Anfrage „blaue Schuhe“ eingibt, wird eine Anzeige von einem Werbetreibenden angezeigt, der Schuhe auf seiner Website verkauft. Wenn keine relevante Anzeige für die Suchanfrage vorhanden ist, wird stattdessen ein organisches Ergebnis angezeigt.
 
-![Suche.png](/img/Suche.png)
+![Search.png](/img/Search.png)
 
 ### Überblick
 

--- a/i18n/de/docusaurus-theme-classic/footer.json
+++ b/i18n/de/docusaurus-theme-classic/footer.json
@@ -35,10 +35,7 @@
     "message": "Lernen",
     "description": "The label of footer link with label=Learn linking to https://brave.com/brave-ads/learn"
   },
-  "copyright": {
-    "message": "Urheberrecht © 2024 Brave Software, Inc.",
-    "description": "The footer copyright"
-  },
+
   "link.item.label.Terms of service": {
     "message": "Nutzungsbedingungen",
     "description": "The label of footer link with label=Terms of service linking to https://basicattentiontoken.org/advertiser-terms-of-service/"

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -35,10 +35,7 @@
     "message": "Learn",
     "description": "The label of footer link with label=Learn linking to https://brave.com/brave-ads/learn"
   },
-  "copyright": {
-    "message": "Copyright © 2024 Brave Software, Inc.",
-    "description": "The footer copyright"
-  },
+
   "link.item.label.Terms of service": {
     "message": "Terms of service",
     "description": "The label of footer link with label=Terms of service linking to https://basicattentiontoken.org/advertiser-terms-of-service/"

--- a/i18n/es/docusaurus-theme-classic/footer.json
+++ b/i18n/es/docusaurus-theme-classic/footer.json
@@ -35,10 +35,7 @@
     "message": "Información",
     "description": "The label of footer link with label=Learn linking to https://brave.com/brave-ads/learn"
   },
-  "copyright": {
-    "message": "Copyright © 2024 Brave Software, Inc.",
-    "description": "The footer copyright"
-  },
+
   "link.item.label.Terms of service": {
     "message": "Términos de servicio",
     "description": "The label of footer link with label=Terms of service linking to https://basicattentiontoken.org/advertiser-terms-of-service/"

--- a/i18n/fr/docusaurus-plugin-content-docs/current/campaign-performance/reporting.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/campaign-performance/reporting.md
@@ -149,7 +149,7 @@ Le rapport de conversion d'annonces vérifiables se fait par un ID de conversion
 - La valeur de l'ID de conversion doit être unique pour chaque conversion. Les valeurs en double d'ID d'événement de conversion entraîneront des divergences comptables.
 - L'ID de conversion doit être compris entre 1 et 30 caractères, ne contenir que des caractères alphanumériques (ainsi que des tirets) et correspondre à cette expression régulière : « [-a-zA-Z0-9]{1,30} ».
 - Les valeurs des événements de plus de 30 caractères échoueront, empêchant l'événement d'être correctement pris en compte. Vous pouvez vérifier si votre identifiant est valide en utilisant un site comme « https://regex101.com/ ».
-- Les ID de conversion ne doivent pas inclure d'identifiants d'utilisateur ou d'informations personnelles identifiables. Par exemple, les ID de conversion tels que « <user id>-<random id> », « <random id>-<email address> » ne sont pas autorisés.
+- Les ID de conversion ne doivent pas inclure d'identifiants d'utilisateur ou d'informations personnelles identifiables. Par exemple, les ID de conversion tels que `<user id>-<random id>`, `<random id>-<email address>` ne sont pas autorisés.
 
 Brave utilise TweetNacl pour chiffrer l'ID de conversion.
 

--- a/i18n/fr/docusaurus-theme-classic/footer.json
+++ b/i18n/fr/docusaurus-theme-classic/footer.json
@@ -35,10 +35,7 @@
     "message": "Apprenez",
     "description": "The label of footer link with label=Learn linking to https://brave.com/brave-ads/learn"
   },
-  "copyright": {
-    "message": "Copyright © 2024 Brave Software, Inc.",
-    "description": "The footer copyright"
-  },
+
   "link.item.label.Terms of service": {
     "message": "Conditions de service",
     "description": "The label of footer link with label=Terms of service linking to https://basicattentiontoken.org/advertiser-terms-of-service/"

--- a/i18n/pt/docusaurus-theme-classic/footer.json
+++ b/i18n/pt/docusaurus-theme-classic/footer.json
@@ -35,10 +35,7 @@
     "message": "Aprender",
     "description": "The label of footer link with label=Learn linking to https://brave.com/brave-ads/learn"
   },
-  "copyright": {
-    "message": "Copyright © 2024 Brave Software, Inc.",
-    "description": "The footer copyright"
-  },
+
   "link.item.label.Terms of service": {
     "message": "Termos de serviço",
     "description": "The label of footer link with label=Terms of service linking to https://basicattentiontoken.org/advertiser-terms-of-service/"

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -49,9 +49,9 @@ h1 sup {
   content: "Beta";
   background: #4A46E0;
   color: white;
-  padding: 1px 4px;
-  border-radius: 6px;
-  font-size: 0.4em;
+  padding: 2px 4px;
+  border-radius: 4px;
+  font-size: 0.5em;
   font-weight: bold;
   text-transform: uppercase;
   letter-spacing: 0.5px;

--- a/src/pages/dynamic-ntt.tsx
+++ b/src/pages/dynamic-ntt.tsx
@@ -175,12 +175,12 @@ export default function DynamicNTT({ src }: DynamicNTTProps): React.JSX.Element 
                         </a>
                       </div>
                       <div>
-                        <a href="/demos/dynamic-ntt/pan-and-zoom-1" className={styles.pageLink}>
+                        <a href="/demos/dynamic-ntt/pan-and-zoom" className={styles.pageLink}>
                           <div id="page1" className={styles.topSiteItem} data-target="page1">
                             <canvas className={styles.pageImageCanvas} width="140" height="140"></canvas>
                             <img src="/img/_icons/social-brave-release-favicon-fullheight-color.png" alt="" draggable={false} />
                           </div>
-                          Pan&Zoom-1
+                          Pan&Zoom
                         </a>
                       </div>
                       <div>


### PR DESCRIPTION
In this PR we have added the following:

- Rename the `Pan& Zoom - 1 ` to `Pan & Zoom` as we only have one pan and zoom demo for now
- Remove all footers from translation as these were overriding the standard footer copyright year defined the in the config
- Add German and French language options in the config and two minor mistakes in translations that made the build to fail for these languages.
- a minor css change to unify the BETA tag design in the sidenav and the dynamic NTT page one.