### PR TITLE
fix: audit fix

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   picomatch@<2.3.2: '>=2.3.2'
   postcss@<8.5.10: ^8.5.10
   qs@<6.14.1: '>=6.14.1'
+  qs@>=6.11.1 <=6.15.1: '>=6.15.2'
   serialize-javascript@<7.0.5: '>=7.0.5'
   uuid@<11.1.1: '>=11.1.1'
   webpack-dev-server@<=5.2.3: '>=5.2.4'
@@ -4169,8 +4170,8 @@ packages:
     resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
     engines: {node: '>=16.0.0'}
 
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -7851,7 +7852,7 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.2
       raw-body: 2.5.2
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -8585,7 +8586,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 3.3.0
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.0
@@ -10528,7 +10529,7 @@ snapshots:
 
   pvutils@1.1.5: {}
 
-  qs@6.15.0:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,8 +8,7 @@ auditConfig:
 blockExoticSubdeps: true
 
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude: [ ]
-
+minimumReleaseAgeExclude: []
 
 overrides:
   '@babel/plugin-transform-modules-systemjs@>=7.12.0 <=7.29.3': '^7.29.4'
@@ -23,6 +22,7 @@ overrides:
   picomatch@<2.3.2: '>=2.3.2'
   postcss@<8.5.10: '^8.5.10'
   qs@<6.14.1: '>=6.14.1'
+  qs@>=6.11.1 <=6.15.1: '>=6.15.2'
   serialize-javascript@<7.0.5: '>=7.0.5'
   uuid@<11.1.1: '>=11.1.1'
   webpack-dev-server@<=5.2.3: '>=5.2.4'


### PR DESCRIPTION
To address:

```
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ moderate            │ qs has a remotely triggerable DoS: qs.stringify        │
│                     │ crashes with TypeError on null/undefined entries in    │
│                     │ comma-format arrays when encodeValuesOnly is set       │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ qs                                                     │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ >=6.11.1 <=6.15.1                                      │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=6.15.2                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>@docusaurus/core>webpack-dev-server>express>qs       │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-q8mj-m7cp-5q26      │
└─────────────────────┴────────────────────────────────────────────────────────┘

```