### PR TITLE
chore(audit): upgrade launch-editor

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   brace-expansion@^5: '>5.0.5'
   fast-uri@<=3.1.1: ^3.1.2
   follow-redirects@<=1.15.11: '>=1.16.0'
+  launch-editor@<=2.8.2: '>=2.9.0'
   lodash@>=4.0.0 <=4.17.22: '>=4.18'
   minimatch@<3.1.4: '>=3.1.4'
   node-forge@<1.4.0: '>=1.4.0'
@@ -3173,8 +3174,8 @@ packages:
     resolution: {integrity: sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==}
     engines: {node: '>=14.16'}
 
-  launch-editor@2.6.1:
-    resolution: {integrity: sha512-eB/uXmFVpY4zezmGp5XtU21kwo7GBbKB+EQ+UZeWtGb9yAM5xt/Evk+lYH3eRNAtId+ej4u7TYPFZ07w4s7rRw==}
+  launch-editor@2.14.1:
+    resolution: {integrity: sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==}
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -4479,8 +4480,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.1:
-    resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+    engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -9222,10 +9224,10 @@ snapshots:
     dependencies:
       package-json: 8.1.1
 
-  launch-editor@2.6.1:
+  launch-editor@2.14.1:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.1
+      shell-quote: 1.8.4
 
   leven@3.1.0: {}
 
@@ -10926,7 +10928,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.1: {}
+  shell-quote@1.8.4: {}
 
   side-channel-list@1.0.0:
     dependencies:
@@ -11398,7 +11400,7 @@ snapshots:
       graceful-fs: 4.2.11
       http-proxy-middleware: 2.0.9(@types/express@4.17.25)
       ipaddr.js: 2.1.0
-      launch-editor: 2.6.1
+      launch-editor: 2.14.1
       open: 10.2.0
       p-retry: 6.2.1
       schema-utils: 4.3.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,7 @@ overrides:
   brace-expansion@^5: '>5.0.5'
   fast-uri@<=3.1.1: '^3.1.2'
   follow-redirects@<=1.15.11: '>=1.16.0'
+  launch-editor@<=2.8.2: '>=2.9.0'
   lodash@>=4.0.0 <=4.17.22: '>=4.18'
   minimatch@<3.1.4: '>=3.1.4'
   node-forge@<1.4.0: '>=1.4.0'


### PR DESCRIPTION
to address:

```
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ launch-editor vulnerable to command injection via the  │
│                     │ crafted request on Windows                             │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ launch-editor                                          │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <=2.8.2                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=2.9.0                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>@docusaurus/core>webpack-dev-server>launch-editor    │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-c27g-q93r-2cwf      │
└─────────────────────┴────────────────────────────────────────────────────────┘
```

https://github.com/brave/brave-ads-docs/security/dependabot/68